### PR TITLE
Troubleshoot coding error

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -48,3 +48,16 @@ subprojects {
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }
+
+subprojects {
+	plugins.withId("com.android.library") {
+		extensions.configure<com.android.build.api.dsl.LibraryExtension> {
+			compileSdk = 34
+		}
+	}
+	plugins.withId("com.android.application") {
+		extensions.configure<com.android.build.api.dsl.ApplicationExtension> {
+			compileSdk = 34
+		}
+	}
+}


### PR DESCRIPTION
Set `compileSdk` for all Android subprojects to resolve "Cannot query the value of this provider" error.

The `sqflite_android` library module was not getting a `compileSdk` set with the existing AGP setup, causing the "Cannot query the value of this provider" error during `compileDebugJavaWithJavac`. This change explicitly sets `compileSdk = 34` for both library and application subprojects in `android/build.gradle.kts` to ensure plugins like `sqflite_android` have a valid boot classpath.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbbfed3b-4561-4173-8aca-692b9aa69c56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbbfed3b-4561-4173-8aca-692b9aa69c56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

